### PR TITLE
fix typo in Vagrantfile: stretch is debian9, not debian8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ PUPPET_VERSION = "5.5.10"
 BOXES = [
   { name: "debian7",  box: "debian/wheezy64",  version: "7.11.2" },
   { name: "debian8",  box: "debian/jessie64",  version: "8.11.0" },
-  { name: "debian8",  box: "debian/stretch64", version: "9.8.0" },
+  { name: "debian9",  box: "debian/stretch64", version: "9.8.0" },
 
   { name: "ubuntu14", box: "ubuntu/trusty64", version: "20190301.0.1" },
   { name: "ubuntu16", box: "ubuntu/xenial64", version: "20190221.0.0" },


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
